### PR TITLE
Support server_state parameter

### DIFF
--- a/lib/omniauth/strategies/mixi.rb
+++ b/lib/omniauth/strategies/mixi.rb
@@ -37,6 +37,10 @@ module OmniAuth
                })
       end
 
+      credentials do
+        { "id_token" => access_token['id_token'] }
+      end
+
       extra do
         hash = {}
         hash['raw_info'] = raw_info unless skip_info?

--- a/lib/omniauth/strategies/mixi.rb
+++ b/lib/omniauth/strategies/mixi.rb
@@ -68,7 +68,13 @@ module OmniAuth
               params[:scope] = BASIC_SCOPE
             end
           end
+          params[:server_state] = get_server_state
+          session['omniauth.server_state'] = params[:server_state]
         end
+      end
+
+      def token_params
+        super.merge(:server_state => session.delete('omniauth.server_state'))
       end
 
       private
@@ -107,6 +113,20 @@ module OmniAuth
           end
         end
         prefecture
+      end
+
+      def get_server_state
+        opts = {
+          :body => {
+            'grant_type' => 'server_state',
+            'client_id' => options.client_id
+          },
+          :headers => { 'Content-Type' => 'application/x-www-form-urlencoded' },
+          :raise_errors => true,
+          :parse => true
+        }
+        response = client.request(:post, options.client_options.token_url, opts)
+        response.parsed['server_state']
       end
     end
   end

--- a/lib/omniauth/strategies/mixi.rb
+++ b/lib/omniauth/strategies/mixi.rb
@@ -127,7 +127,7 @@ module OmniAuth
           },
           :headers => { 'Content-Type' => 'application/x-www-form-urlencoded' },
           :raise_errors => true,
-          :parse => true
+          :parse => :json
         }
         response = client.request(:post, options.client_options.token_url, opts)
         response.parsed['server_state']

--- a/spec/omniauth/strategies/mixi_spec.rb
+++ b/spec/omniauth/strategies/mixi_spec.rb
@@ -33,6 +33,7 @@ describe OmniAuth::Strategies::Mixi do
       target = OmniAuth::Strategies::Mixi.new(nil, *args).tap do |strategy|
         strategy.stub!(:request).and_return(request)
         strategy.stub!(:session).and_return({})
+        strategy.stub!(:get_server_state)
       end
       target.authorize_params[:scope].should == 'r_profile'
     end
@@ -44,6 +45,7 @@ describe OmniAuth::Strategies::Mixi do
       target = OmniAuth::Strategies::Mixi.new(nil, *args).tap do |strategy|
         strategy.stub!(:request).and_return(request)
         strategy.stub!(:session).and_return({})
+        strategy.stub!(:get_server_state)
       end
       target.authorize_params[:scope].should ==
         'r_profile r_profile_name r_profile_location r_profile_about_me'
@@ -56,6 +58,7 @@ describe OmniAuth::Strategies::Mixi do
       target = OmniAuth::Strategies::Mixi.new(nil, *args).tap do |strategy|
         strategy.stub!(:request).and_return(request)
         strategy.stub!(:session).and_return({})
+        strategy.stub!(:get_server_state)
       end
       target.authorize_params[:scope].should == 'r_profile r_voice'
     end
@@ -67,6 +70,7 @@ describe OmniAuth::Strategies::Mixi do
       target = OmniAuth::Strategies::Mixi.new(nil, *args).tap do |strategy|
         strategy.stub!(:request).and_return(request)
         strategy.stub!(:session).and_return({})
+        strategy.stub!(:get_server_state)
       end
       target.authorize_params[:display].should == 'touch'
     end
@@ -78,8 +82,31 @@ describe OmniAuth::Strategies::Mixi do
       target = OmniAuth::Strategies::Mixi.new(nil, *args).tap do |strategy|
         strategy.stub!(:request).and_return(request)
         strategy.stub!(:session).and_return({})
+        strategy.stub!(:get_server_state)
       end
       target.authorize_params[:display].should == 'touch'
+    end
+
+    it 'should include the server_state parameter' do
+      request = stub('Request')
+      request.stub!(:params).and_return({})
+      target = subject.tap do |strategy|
+        strategy.stub!(:request).and_return(request)
+        strategy.stub!(:session).and_return({})
+        strategy.stub!(:get_server_state).and_return('serverState1')
+      end
+      target.authorize_params[:server_state].should == 'serverState1'
+      target.session['omniauth.server_state'].should == 'serverState1'
+    end
+  end
+
+  describe 'Token params' do
+    it 'should include the server_state parameter' do
+      target = subject.tap do |strategy|
+        strategy.stub!(:session).
+          and_return('omniauth.server_state' => 'serverState1')
+      end
+      target.token_params['server_state'].should == 'serverState1'
     end
   end
 


### PR DESCRIPTION
Mixi's new authentication method recommends to use `server_state` parameter.
http://developer.mixi.co.jp/connect/mixi_graph_api/api_auth/
When `scope` parameter includes `openid`, `server_state` is surely required.

And I wrote `credentials` block to return `id_token` because this token is needed to migrate from mixi OpenID.
http://developer.mixi.co.jp/connect/mixi_graph_api/migration_from_mixi_openid/
