### PR TITLE
Redifine callback_url to remove query strings

### DIFF
--- a/lib/omniauth/strategies/mixi.rb
+++ b/lib/omniauth/strategies/mixi.rb
@@ -49,6 +49,10 @@ module OmniAuth
           access_token.get('/2/people/@me/@self?fields=@all').parsed['entry']
       end
 
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       def authorize_params
         super.tap do |params|
           %w[display state scope].each do |v|


### PR DESCRIPTION
Follow the change made in `omniauth-oauth2` gem v1.4.0,
  https://github.com/intridea/omniauth-oauth2/commit/26152673224aca5c3e918bcc83075dbb0659717f
  which changed OmniAuth::Strategies::OAuth2#callback_url to include query
  strings, while it is used to create `redirect_uri`, which should not
  include querey strings.

As https://github.com/intridea/omniauth-oauth2/issues/81
   ( especially https://github.com/intridea/omniauth-oauth2/issues/81#issuecomment-168899933 )
    suggests, downstream gems are to define their own `callback_url`.

refs #3 
